### PR TITLE
Add specific output for receiving SEGFAULT.

### DIFF
--- a/IZP2tester_zs2020.py
+++ b/IZP2tester_zs2020.py
@@ -27,8 +27,12 @@ class TestCase:
                 self.actual_output = test_input_file.read().decode("utf-8")
             except TimeoutError:
                 self.actual_output = "TIMED OUT"
-            except subprocess.CalledProcessError:
-                self.actual_output = "ERROR"
+            except subprocess.CalledProcessError as err:
+                # -11 represents SEGFAULT: https://code-examples.net/en/q/11dd30f
+                if err.returncode == -11:
+                    self.actual_output = "SEGFAULT"
+                else:
+                    self.actual_output = "ERROR"
 
     def is_passed(self):
         if self.expected_output != 'ERROR':


### PR DESCRIPTION
This PR changes the behavior of handling subprocess execution to output "SEGFAULT" when tested program segfaults.
I tested locally that it is working.